### PR TITLE
Improve Docker docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,39 @@
 # Nebula
 A developer dashboard for apps and tools
 
-## Setup
+## Requirements
+
+- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/) installed
+- Node.js 20+ if you prefer running the services outside of Docker
+
+## Quick start with Docker
+
+The easiest way to run Nebula is with Docker Compose which spins up Postgres, the API server and the Angular front‑end. Everything can be built and started with a single command:
+
+```bash
+docker-compose up --build
+```
+
+Alternatively you can run the provided helper script:
+
+```bash
+./start.sh
+```
+
+Once the services are running, open [http://localhost:4200](http://localhost:4200) in your browser. The API will be available on [http://localhost:3000](http://localhost:3000).
+
+Environment variables for the backend are defined in `backend/.env.example`. You can create your own `backend/.env` file with the same keys to override the defaults.
+
+To stop the stack press `Ctrl+C` and then run:
+
+```bash
+docker-compose down
+```
+
+## Running without Docker
 
 ### Backend
+
 ```bash
 cd backend
 npm install
@@ -11,14 +41,9 @@ npm run dev
 ```
 
 ### Frontend
+
 ```bash
 cd frontend
 npm install
 npm start
-```
-
-### Docker
-Use docker-compose to run Postgres, backend, and frontend services.
-```bash
-docker-compose up --build
 ```

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Simple helper script to build and run the full stack using Docker Compose
+set -e
+
+docker-compose up --build


### PR DESCRIPTION
## Summary
- improve README with detailed Docker instructions
- add helper script to run the Docker stack

## Testing
- `npm test` *(fails: Missing script)*
- `docker-compose config` *(fails: command not found)*
- `npm install`
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684261f20e308328b803e61ea85afc00