### PR TITLE
Fix Angular bootstrap issue and enable sourcemaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Node
+node_modules/
+# Angular build outputs
+frontend/dist/
+frontend/.angular/
+# Logs
+npm-debug.log*
+# Env
+.env
+backend/dist/

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -17,7 +17,8 @@
             "tsConfig": "tsconfig.json",
             "assets": ["src/favicon.ico", "src/assets"],
             "styles": ["src/styles.scss"],
-            "scripts": []
+            "scripts": [],
+            "sourceMap": true
           }
         },
         "serve": {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,4 +1,7 @@
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+// Zone.js is required for Angular's change detection to work properly.
+// Without this import the application bootstrapping fails silently.
+import 'zone.js';
 import { AppModule } from './app/app.module';
 
 platformBrowserDynamic()


### PR DESCRIPTION
## Summary
- import `zone.js` in Angular main.ts so the app boots up correctly
- generate sourcemaps in Angular builds
- ignore build output and node modules

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68426b54533c8328a784385391c59ae9